### PR TITLE
Update server.js

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,8 +11,6 @@ app.use(cors())
 
 mongoose
   .connect(process.env.MONGO_URI, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
   })
   .then(() => {
     console.log('Database connected')


### PR DESCRIPTION
useUnifiedTopology is a deprecated option: useUnifiedTopology has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version

useNewUrlParser is a deprecated option: useNewUrlParser has no effect since Node.js Driver version 4.0.0 and will be removed in the next major version